### PR TITLE
fix(ui): Use correct Flet alignment constants

### DIFF
--- a/webapp_system/src/ui/components/admin/model_management.py
+++ b/webapp_system/src/ui/components/admin/model_management.py
@@ -189,7 +189,7 @@ def _model_card(m: dict, on_refresh) -> ft.Control:
                         ft.Container(
                             width=40, height=40, border_radius=14,
                             bgcolor=ft.Colors.with_opacity(0.18, loai_color),
-                            alignment=ft.Alignment.CENTER,
+                            alignment=ft.alignment.center,
                             content=ft.Icon(loai_icon, size=20, color=loai_color),
                         ),
                         ft.Column(tight=True, spacing=2, controls=[

--- a/webapp_system/src/ui/components/admin/profile_admin.py
+++ b/webapp_system/src/ui/components/admin/profile_admin.py
@@ -17,7 +17,7 @@ def build_profile_admin(page: ft.Page, on_back=None):
         border_radius=48,
         bgcolor=ft.Colors.with_opacity(0.30, PRIMARY),
         border=ft.border.all(2.5, ft.Colors.with_opacity(0.55, ft.Colors.WHITE)),
-        alignment=ft.Alignment.CENTER,
+        alignment=ft.alignment.center,
         clip_behavior=ft.ClipBehavior.ANTI_ALIAS,
     )
     msg = ft.Text("", size=12)

--- a/webapp_system/src/ui/components/user/expert/profile_expert.py
+++ b/webapp_system/src/ui/components/user/expert/profile_expert.py
@@ -17,7 +17,7 @@ def build_profile_expert(page: ft.Page, on_back=None):
         border_radius=48,
         bgcolor=ft.Colors.with_opacity(0.30, PRIMARY),
         border=ft.border.all(2.5, ft.Colors.with_opacity(0.55, ft.Colors.WHITE)),
-        alignment=ft.Alignment.CENTER,
+        alignment=ft.alignment.center,
         clip_behavior=ft.ClipBehavior.ANTI_ALIAS,
     )
     msg = ft.Text("", size=12)

--- a/webapp_system/src/ui/components/user/framer/health_consulting.py
+++ b/webapp_system/src/ui/components/user/framer/health_consulting.py
@@ -952,7 +952,7 @@ def _make_ai_chat(page: ft.Page, on_back=None):  # noqa: C901
     send_btn = ft.Container(
         width=40, height=40, border_radius=20,
         bgcolor=PRIMARY,
-        alignment=ft.Alignment.CENTER,
+        alignment=ft.alignment.center,
         ink=True,
         on_click=_send_text,
         content=ft.Icon(ft.Icons.SEND_ROUNDED, size=18, color=ft.Colors.WHITE),

--- a/webapp_system/src/ui/components/user/framer/live_monitoring.py
+++ b/webapp_system/src/ui/components/user/framer/live_monitoring.py
@@ -78,7 +78,7 @@ class LiveMonitoringController:
                             height=220,
                             border_radius=12,
                             bgcolor=ft.Colors.with_opacity(0.2, ft.Colors.BLACK),
-                            alignment=ft.Alignment.CENTER,
+                            alignment=ft.alignment.center,
                             content=self.stream_image,
                         ),
                         ft.Row(controls=[self.connect_btn, self.snapshot_btn]),

--- a/webapp_system/src/ui/components/user/framer/profile_farmer.py
+++ b/webapp_system/src/ui/components/user/framer/profile_farmer.py
@@ -17,7 +17,7 @@ def build_profile_farmer(page: ft.Page, on_back=None):
         border_radius=48,
         bgcolor=ft.Colors.with_opacity(0.30, PRIMARY),
         border=ft.border.all(2.5, ft.Colors.with_opacity(0.55, ft.Colors.WHITE)),
-        alignment=ft.Alignment.CENTER,
+        alignment=ft.alignment.center,
         clip_behavior=ft.ClipBehavior.ANTI_ALIAS,
     )
     msg = ft.Text("", size=12)

--- a/webapp_system/src/ui/theme.py
+++ b/webapp_system/src/ui/theme.py
@@ -124,7 +124,7 @@ def section_title(icon_name: str, text: str, subtitle: str = "") -> ft.Control:
 def empty_state(text: str = "Không có dữ liệu") -> ft.Control:
     return ft.Container(
         padding=24,
-        alignment=ft.Alignment.CENTER,
+        alignment=ft.alignment.center,
         content=ft.Column(
             horizontal_alignment=ft.CrossAxisAlignment.CENTER,
             tight=True,
@@ -257,8 +257,8 @@ def build_background(content: ft.Control):
                 expand=True,
                 image=ft.DecorationImage(src="backround.png", fit="cover"),
                 gradient=ft.LinearGradient(
-                    begin=ft.Alignment.TOP_LEFT,
-                    end=ft.Alignment.BOTTOM_RIGHT,
+                    begin=ft.alignment.top_left,
+                    end=ft.alignment.bottom_right,
                     colors=["#0B1E2A99", "#17384Acc"],
                 ),
             ),
@@ -362,7 +362,7 @@ def _build_avatar_btn(page: ft.Page | None, on_profile=None) -> ft.Control:
         border_radius=19,
         bgcolor=ft.Colors.with_opacity(0.30, PRIMARY),
         border=ft.border.all(2, ft.Colors.with_opacity(0.55, ft.Colors.WHITE)),
-        alignment=ft.Alignment.CENTER,
+        alignment=ft.alignment.center,
         clip_behavior=ft.ClipBehavior.ANTI_ALIAS,
         tooltip="Hồ sơ cá nhân",
         on_click=lambda e: on_profile() if on_profile else None,
@@ -586,7 +586,7 @@ def build_auth_shell(title: str, description: str, form_controls: list[ft.Contro
             controls=[
                 ft.Container(
                     expand=True,
-                    alignment=ft.Alignment.CENTER,
+                    alignment=ft.alignment.center,
                     padding=ft.padding.symmetric(horizontal=16, vertical=36),
                     content=form_card,
                 ),


### PR DESCRIPTION
Replace invalid ft.Alignment.* constants with ft.alignment.* so the auth shell and related screens render on the current Flet release without runtime AttributeError.

Fixes #11