### PR TITLE
docs: add SECURITY.md and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,19 +160,14 @@ build_role_shell(page, role="farmer", content=my_screen)
 
 ### 🔒 Security
 
-We take security seriously. If you discover a vulnerability, please follow responsible disclosure:
+We take security seriously. Please read our full [Security Policy](SECURITY.md) before reporting.
 
-- **Do NOT** open a public GitHub issue for security vulnerabilities
-- **Email** the maintainers directly with details of the vulnerability
-- Allow up to **72 hours** for an initial response
-- We will coordinate a fix and disclosure timeline with you
-
-**Security practices in this project:**
-- Passwords hashed with SHA-256 (no plaintext storage)
-- Session data cleared on logout via `page.data` purge
-- No credentials committed to the repository
-- `.env` files and secrets are gitignored by default
+**Quick summary:**
+- **Do NOT** open a public GitHub issue for vulnerabilities — email maintainers directly
+- Passwords hashed with SHA-256 · sessions cleared on logout · no credentials in repo
 - Default seed accounts use weak passwords — **change before any production deployment**
+
+→ See [SECURITY.md](SECURITY.md) for supported versions, reporting instructions, and known limitations.
 
 ### 🤝 Contributing
 
@@ -290,17 +285,14 @@ python webapp_system/src/main.py
 
 ### 🔒 Bảo mật
 
-Nếu phát hiện lỗ hổng bảo mật:
-- **Không** mở public issue trên GitHub
-- **Liên hệ trực tiếp** với maintainers qua email kèm chi tiết
-- Chờ phản hồi trong vòng **72 giờ**
+Xem chính sách bảo mật đầy đủ tại [SECURITY.md](SECURITY.md).
 
-**Thực hành bảo mật trong dự án:**
-- Mật khẩu được hash SHA-256 — không lưu plaintext
-- Session bị xóa hoàn toàn khi đăng xuất
-- Không commit credential vào repository
-- File `.env` và secrets đều được gitignore
+**Tóm tắt:**
+- **Không** mở public issue — liên hệ maintainers trực tiếp qua email
+- Mật khẩu hash SHA-256 · session xóa khi đăng xuất · không commit credential
 - Tài khoản seed mặc định có mật khẩu yếu — **thay đổi trước khi deploy production**
+
+→ Xem [SECURITY.md](SECURITY.md) để biết phiên bản được hỗ trợ, hướng dẫn báo cáo, và các giới hạn đã biết.
 
 ### 🤝 Đóng góp
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,125 @@
+# Security Policy
+
+<a href="#english">🇬🇧 English</a> · <a href="#vietnamese">🇻🇳 Tiếng Việt</a>
+
+---
+
+<a id="english"></a>
+
+## 🇬🇧 English
+
+### Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| `main` branch | ✅ Active |
+| `dev*` branches | ⚠️ Development only |
+| Older releases | ❌ Not supported |
+
+### Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues privately:
+
+1. **Email:** [trantandatt.26@gmail.com](mailto:trantandatt.26@gmail.com)
+2. **Subject:** `[SECURITY] Con Bò Cười — <brief description>`
+3. **Include:**
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (optional)
+
+We will acknowledge your report within **72 hours** and aim to release a fix within **14 days** for critical issues.
+
+### Security Practices
+
+| Area | Practice |
+|------|----------|
+| **Passwords** | SHA-256 hashed — no plaintext storage |
+| **Sessions** | Cleared on logout via `page.data` purge |
+| **Secrets** | `.env` and credential files are gitignored |
+| **Seed accounts** | Weak default passwords — change before any production deployment |
+| **Dependencies** | No auto-pinned versions; review before upgrading |
+
+### Known Limitations
+
+- **SHA-256 without salt** — passwords are vulnerable to rainbow table attacks. A future phase will migrate to bcrypt/argon2.
+- **JSON file store** — not suitable for multi-user production; meant for local/LAN use only.
+- **No HTTPS enforcement** — web mode over LAN should be fronted by a reverse proxy with TLS for production deployments.
+
+### Scope
+
+The following are **in scope** for vulnerability reports:
+
+- Authentication bypass or privilege escalation
+- Injection vulnerabilities (command, path traversal)
+- Sensitive data exposure (credentials, session tokens)
+- Insecure deserialization from JSON store
+
+The following are **out of scope:**
+
+- Denial-of-service against a local desktop instance
+- Social engineering
+- Issues in dependencies not exploitable via this application
+
+---
+
+<a id="vietnamese"></a>
+
+## 🇻🇳 Tiếng Việt
+
+### Phiên bản được hỗ trợ
+
+| Phiên bản | Hỗ trợ |
+|-----------|--------|
+| Nhánh `main` | ✅ Đang hoạt động |
+| Nhánh `dev*` | ⚠️ Chỉ dùng phát triển |
+| Bản phát hành cũ | ❌ Không hỗ trợ |
+
+### Báo cáo lỗ hổng bảo mật
+
+**Không mở public issue trên GitHub cho các lỗ hổng bảo mật.**
+
+Vui lòng báo cáo bằng cách:
+
+1. **Email:** [trantandatt.26@gmail.com](mailto:trantandatt.26@gmail.com)
+2. **Tiêu đề:** `[SECURITY] Con Bò Cười — <mô tả ngắn>`
+3. **Nội dung bao gồm:**
+   - Mô tả lỗ hổng
+   - Các bước tái hiện
+   - Mức độ ảnh hưởng
+   - Đề xuất cách sửa (nếu có)
+
+Chúng tôi sẽ xác nhận báo cáo trong vòng **72 giờ** và cố gắng phát hành bản vá trong **14 ngày** với các vấn đề nghiêm trọng.
+
+### Thực hành bảo mật
+
+| Khu vực | Thực hành |
+|---------|-----------|
+| **Mật khẩu** | Hash SHA-256 — không lưu plaintext |
+| **Phiên làm việc** | Xóa hoàn toàn khi đăng xuất qua `page.data` |
+| **Secrets** | File `.env` và credential được gitignore |
+| **Tài khoản seed** | Mật khẩu mặc định yếu — **đổi trước khi deploy production** |
+| **Dependencies** | Không tự động pin phiên bản; kiểm tra trước khi nâng cấp |
+
+### Giới hạn đã biết
+
+- **SHA-256 không có salt** — dễ bị tấn công rainbow table. Phase tương lai sẽ chuyển sang bcrypt/argon2.
+- **Lưu trữ file JSON** — không phù hợp cho production đa người dùng; chỉ dùng cho local/LAN.
+- **Không bắt buộc HTTPS** — web mode qua LAN cần reverse proxy với TLS cho môi trường production.
+
+### Phạm vi
+
+**Trong phạm vi** báo cáo:
+
+- Bypass xác thực hoặc leo thang đặc quyền
+- Lỗ hổng injection (command injection, path traversal)
+- Lộ thông tin nhạy cảm (credentials, session token)
+- Deserialization không an toàn từ JSON store
+
+**Ngoài phạm vi:**
+
+- Tấn công DoS vào desktop instance cục bộ
+- Social engineering
+- Lỗi trong dependency không khai thác được qua ứng dụng này


### PR DESCRIPTION
## Summary
- Add bilingual (EN/VI) `SECURITY.md` as GitHub security policy page
- Covers: supported versions, responsible disclosure (email + 72h SLA), security practices, known limitations (SHA-256 no salt, JSON store, no HTTPS), and in/out-of-scope definitions
- Update both EN and VI README security sections to link to `SECURITY.md` instead of repeating inline detail

## Test plan
- [ ] Verify `SECURITY.md` renders correctly on GitHub
- [ ] Verify README links to `SECURITY.md` work in both EN and VI sections